### PR TITLE
Fix ampersand issue

### DIFF
--- a/RDCManager/public/DSL/RdcGroup.ps1
+++ b/RDCManager/public/DSL/RdcGroup.ps1
@@ -15,12 +15,11 @@ function RdcGroup {
         throw ('{0} must be nested in RdcDocument or RdcGroup: {1}' -f $myinvocation.InvocationName, $_.Exception.Message)
     }
 
-    $xElement = $currentNode = [System.Xml.Linq.XElement]('
-        <group>
-            <properties>
-                <name>{0}</name>
-            </properties>
-        </group>' -f $Name)
+    $xElement = $currentNode = [System.Xml.Linq.XElement]::new('group',
+        [System.Xml.Linq.XElement]::new('properties',
+            [System.Xml.Linq.XElement]::new('name', $Name)
+        )
+    )
 
     if ($parentNode -is [System.Xml.Linq.XDocument]) {
         $parentNode.Element('Rdc').Element('file').Add($xElement)


### PR DESCRIPTION
Fixes #6 

This PR changes the RdcGroup function to use XElement ctor to enable proper parsing of ampersands.

Example of proper parsing in the gif below:
![iupWxWElYH](https://user-images.githubusercontent.com/20758758/67343194-7877e400-f52c-11e9-8f3b-6f0e2adcb765.gif)

