### PR TITLE
Allow credentials to be set at rdcdocument level

### DIFF
--- a/RDCManager/public/DSL/RdcLogonCredential.ps1
+++ b/RDCManager/public/DSL/RdcLogonCredential.ps1
@@ -97,5 +97,11 @@ function RdcLogonCredential {
             <domain>{2}</domain>
         </logonCredentials>' -f $username, $encryptedPassword, $domainName)
 
-    $parentNode.Element('properties').AddAfterSelf($xElement)
+    if ($parentNode.NodeType -eq 'Document') {
+        $propertiesElement = $parentNode.FirstNode.Element('file').Element('properties')
+    }
+    else {
+        $propertiesElement = $parentNode.Element('properties')
+    }
+    $propertiesElement.AddAfterSelf($xElement)
 }


### PR DESCRIPTION
Currently you cannot set credentials at the RdcDocument level as you get the following error:
![image](https://user-images.githubusercontent.com/20758758/71726148-1c83e280-2e2e-11ea-9142-6c60376986d4.png)

This PR implements a fix so that credentials can be set at the RdcDocument level.