### PR TITLE
Assembly fix for Pwsh 7.2 import error

### DIFF
--- a/RDCManager/InitializeModule.ps1
+++ b/RDCManager/InitializeModule.ps1
@@ -1,5 +1,4 @@
-using namespace System.Xml.Linq
-using assembly System.Xml.Linq
+Add-Type -AssemblyName System.Xml.Linq
 
 function InitializeModule {
     Set-RdcConfiguration -Reset

--- a/RDCManager/RdcManager.psd1
+++ b/RDCManager/RdcManager.psd1
@@ -12,7 +12,7 @@
 RootModule = 'RDCManager.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.1.2'
+ModuleVersion = '2.1.3'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'


### PR DESCRIPTION
Fixes #15 

Changed `using assembly` to `Add-Type` to fix import error on newer versions of PowerShell