### PR TITLE
Add basic Pester configuration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,23 @@
+name: Unit tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Perform Pester tests
+        shell: pwsh
+        run: |
+          Invoke-Pester -Passthru

--- a/RDCManager/InitializeModule.Tests.ps1
+++ b/RDCManager/InitializeModule.Tests.ps1
@@ -1,0 +1,15 @@
+BeforeAll {
+    . $PSCommandPath.Replace('.Tests.ps1','.ps1')
+
+    function Set-RdcConfiguration {}
+}
+
+Describe "InitializeModule" {
+    BeforeAll {
+        Mock -Verifiable Set-RdcConfiguration {}
+    }
+    It "Resets the configuration" {
+        InitializeModule
+        Should -InvokeVerifiable
+    }
+}


### PR DESCRIPTION
This commit adds a GitHub action to run Pester unit tests. This commit also includes a single test to ensure that Pester is indeed being executed.